### PR TITLE
first pass of lightweight modifications for 2v2 (vs 3v3) play

### DIFF
--- a/field/arena.go
+++ b/field/arena.go
@@ -216,10 +216,10 @@ func (arena *Arena) LoadMatch(match *model.Match) error {
 	if err != nil {
 		return err
 	}
-	err = arena.assignTeam(match.Red3, "R3")
-	if err != nil {
-		return err
-	}
+	// err = arena.assignTeam(match.Red3, "R3")
+	// if err != nil {
+	// 	return err
+	// }
 	err = arena.assignTeam(match.Blue1, "B1")
 	if err != nil {
 		return err
@@ -699,7 +699,7 @@ func (arena *Arena) checkCanStartMatch() error {
 		return fmt.Errorf("Cannot start match while there is a match still in progress or with results pending.")
 	}
 
-	err := arena.checkAllianceStationsReady("R1", "R2", "R3", "B1", "B2", "B3")
+	err := arena.checkAllianceStationsReady("R1", "R2", "B1", "B2")
 	if err != nil {
 		return err
 	}

--- a/field/arena.go
+++ b/field/arena.go
@@ -216,10 +216,10 @@ func (arena *Arena) LoadMatch(match *model.Match) error {
 	if err != nil {
 		return err
 	}
-	// err = arena.assignTeam(match.Red3, "R3")
-	// if err != nil {
-	// 	return err
-	// }
+	err = arena.assignTeam(match.Red3, "R3")
+	if err != nil {
+		return err
+	}
 	err = arena.assignTeam(match.Blue1, "B1")
 	if err != nil {
 		return err

--- a/field/arena.go
+++ b/field/arena.go
@@ -371,10 +371,10 @@ func (arena *Arena) ResetMatch() error {
 	arena.matchAborted = false
 	arena.AllianceStations["R1"].Bypass = false
 	arena.AllianceStations["R2"].Bypass = false
-	arena.AllianceStations["R3"].Bypass = false
+	arena.AllianceStations["R3"].Bypass = true
 	arena.AllianceStations["B1"].Bypass = false
 	arena.AllianceStations["B2"].Bypass = false
-	arena.AllianceStations["B3"].Bypass = false
+	arena.AllianceStations["B3"].Bypass = true
 	arena.MuteMatchSounds = false
 	return nil
 }

--- a/templates/audience_display.html
+++ b/templates/audience_display.html
@@ -22,13 +22,11 @@
             <div class="teams" id="leftTeams">
               <div id="leftTeam1"></div>
               <div id="leftTeam2"></div>
-              <div id="leftTeam3"></div>
             </div>
             <div class="score reversible-left">
               <div class="avatars">
                 <img class="avatar" id="leftTeam1Avatar" src="" />
                 <img class="avatar" id="leftTeam2Avatar" src="" />
-                <img class="avatar" id="leftTeam3Avatar" src="" />
               </div>
               <div class="score-number" id="leftScoreNumber"></div>
             </div>
@@ -37,13 +35,11 @@
               <div class="avatars">
                 <img class="avatar" id="rightTeam1Avatar" src="" />
                 <img class="avatar" id="rightTeam2Avatar" src="" />
-                <img class="avatar" id="rightTeam3Avatar" src="" />
               </div>
             </div>
             <div class="teams" id="rightTeams">
               <div id="rightTeam1"></div>
               <div id="rightTeam2"></div>
-              <div id="rightTeam3"></div>
             </div>
           </div>
           <div id="eventMatchInfo">
@@ -77,12 +73,10 @@
         <div class="final-teams" id="leftFinalTeams">
           <div class="final-team" id="leftFinalTeam1"></div><img class="final-avatar" id="leftFinalTeam1Avatar" src="" />
           <div class="final-team" id="leftFinalTeam2"></div><img class="final-avatar" id="leftFinalTeam2Avatar" src="" />
-          <div class="final-team" id="leftFinalTeam3"></div><img class="final-avatar" id="leftFinalTeam3Avatar" src="" />
         </div>
         <div class="final-teams" id="rightFinalTeams">
           <div class="final-team" id="rightFinalTeam1"></div><img class="final-avatar" id="rightFinalTeam1Avatar" src="" />
           <div class="final-team" id="rightFinalTeam2"></div><img class="final-avatar" id="rightFinalTeam2Avatar" src="" />
-          <div class="final-team" id="rightFinalTeam3"></div><img class="final-avatar" id="rightFinalTeam3Avatar" src="" />
         </div>
         <div class="final-breakdown" id="leftFinalBreakdown">
           <span class="valign-cell">

--- a/templates/base.html
+++ b/templates/base.html
@@ -89,10 +89,8 @@
                   <li class="dropdown-header">Alliance Station</li>
                   <li><a href="/displays/alliance_station?station=R1">Red 1</a></li>
                   <li><a href="/displays/alliance_station?station=R2">Red 2</a></li>
-                  <li><a href="/displays/alliance_station?station=R3">Red 3</a></li>
                   <li><a href="/displays/alliance_station?station=B1">Blue 1</a></li>
                   <li><a href="/displays/alliance_station?station=B2">Blue 2</a></li>
-                  <li><a href="/displays/alliance_station?station=B3">Blue 3</a></li>
                   <li><a href="/displays/alliance_station?station=N2">Clock</a></li>
                   <li><a href="/displays/alliance_station?station=N3">Red Score</a></li>
                   <li><a href="/displays/alliance_station?station=N1">Blue Score</a></li>

--- a/templates/edit_match_result.html
+++ b/templates/edit_match_result.html
@@ -46,9 +46,9 @@
   var matchId = {{.Match.Id}};
   matchResult = jQuery.parseJSON('{{.MatchResultJson}}');
   allianceResults["red"] = {alliance: "red", team1: {{.Match.Red1}}, team2: {{.Match.Red2}},
-      team3: {{.Match.Red3}}, score: matchResult.RedScore};
+      score: matchResult.RedScore};
   allianceResults["blue"] = {alliance: "blue", team1: {{.Match.Blue1}}, team2: {{.Match.Blue2}},
-      team3: {{.Match.Blue3}}, score: matchResult.BlueScore};
+      score: matchResult.BlueScore};
   renderResults("red");
   renderResults("blue");
 </script>

--- a/templates/field_monitor_display.html
+++ b/templates/field_monitor_display.html
@@ -17,9 +17,8 @@
     <link rel="stylesheet" href="/static/css/field_monitor_display.css" />
   </head>
   <body>
-    {{template "row" dict "leftPosition" "1" "rightPosition" "3"}}
-    {{template "row" dict "leftPosition" "2" "rightPosition" "2"}}
-    {{template "row" dict "leftPosition" "3" "rightPosition" "1"}}
+    {{template "row" dict "leftPosition" "1" "rightPosition" "2"}}
+    {{template "row" dict "leftPosition" "2" "rightPosition" "1"}}
     <div id="eventStatusRow">
       <div id="cycleTimeMessage"></div>
       <div id="earlyLateMessage"></div>

--- a/templates/match_play.html
+++ b/templates/match_play.html
@@ -76,7 +76,6 @@
         </div>
         {{template "matchPlayTeam" dict "team" .Match.Blue1 "color" "B" "position" 1 "data" .}}
         {{template "matchPlayTeam" dict "team" .Match.Blue2 "color" "B" "position" 2 "data" .}}
-        {{template "matchPlayTeam" dict "team" .Match.Blue3 "color" "B" "position" 3 "data" .}}
         {{if eq .Match.Type "elimination" }}
           <div>
             <b>Alliance {{.Match.ElimBlueAlliance}}</b>
@@ -94,7 +93,6 @@
           <div class="col-lg-2" data-toggle="tooltip" title="Robot">Rbt</div>
           <div class="col-lg-2" data-toggle="tooltip" title="Bypass/Disable">Byp</div>
         </div>
-        {{template "matchPlayTeam" dict "team" .Match.Red3 "color" "R" "position" 3 "data" .}}
         {{template "matchPlayTeam" dict "team" .Match.Red2 "color" "R" "position" 2 "data" .}}
         {{template "matchPlayTeam" dict "team" .Match.Red1 "color" "R" "position" 1 "data" .}}
         {{if eq .Match.Type "elimination" }}

--- a/templates/match_review.html
+++ b/templates/match_review.html
@@ -39,10 +39,10 @@
                 <td>{{$match.DisplayName}}</td>
                 <td>{{$match.Time}}</td>
                 <td class="text-center red-text">
-                  {{index $match.RedTeams 0}}, {{index $match.RedTeams 1}}, {{index $match.RedTeams 2}}
+                  {{index $match.RedTeams 0}}, {{index $match.RedTeams 1}}
                 </td>
                 <td class="text-center blue-text">
-                  {{index $match.BlueTeams 0}}, {{index $match.BlueTeams 1}}, {{index $match.BlueTeams 2}}
+                  {{index $match.BlueTeams 0}}, {{index $match.BlueTeams 1}}
                 </td>
                 <td class="text-center red-text">{{if $match.IsComplete}}{{$match.RedScore}}{{end}}</td>
                 <td class="text-center blue-text">{{if $match.IsComplete}}{{$match.BlueScore}}{{end}}</td>

--- a/templates/queueing_display.html
+++ b/templates/queueing_display.html
@@ -55,13 +55,12 @@
         <div class="col-lg-1 avatars text-right">
           <img class="avatar" src="/api/teams/{{$match.Red1}}/avatar" /><br />
           <img class="avatar" src="/api/teams/{{$match.Red2}}/avatar" /><br />
-          <img class="avatar" src="/api/teams/{{$match.Red3}}/avatar" />
         </div>
         <div class="col-lg-2 red-teams">
           {{if $match.Red1}}
             <div class="row">
               <div class="col-lg-7">
-                {{$match.Red1}}<br />{{$match.Red2}}<br />{{$match.Red3}}
+                {{$match.Red1}}<br />{{$match.Red2}}<br />
                 {{range $team := (index $.RedOffFieldTeams $i) }}
                   <br />{{$team}}
                 {{end}}
@@ -88,7 +87,7 @@
                 {{end}}
               </div>
               <div class="col-lg-7">
-                {{$match.Blue1}}<br />{{$match.Blue2}}<br />{{$match.Blue3}}
+                {{$match.Blue1}}<br />{{$match.Blue2}}<br />
                 {{range $team := (index $.BlueOffFieldTeams $i) }}
                 <br />{{$team}}
                 {{end}}
@@ -99,7 +98,6 @@
         <div class="col-lg-1 avatars">
           <img class="avatar" src="/api/teams/{{$match.Blue1}}/avatar" /><br />
           <img class="avatar" src="/api/teams/{{$match.Blue2}}/avatar" /><br />
-          <img class="avatar" src="/api/teams/{{$match.Blue3}}/avatar" />
         </div>
       </div>
     {{end}}

--- a/templates/queueing_display.html
+++ b/templates/queueing_display.html
@@ -60,7 +60,7 @@
           {{if $match.Red1}}
             <div class="row">
               <div class="col-lg-7">
-                {{$match.Red1}}<br />{{$match.Red2}}<br />
+                {{$match.Red1}}<br />{{$match.Red2}}
                 {{range $team := (index $.RedOffFieldTeams $i) }}
                   <br />{{$team}}
                 {{end}}
@@ -87,7 +87,7 @@
                 {{end}}
               </div>
               <div class="col-lg-7">
-                {{$match.Blue1}}<br />{{$match.Blue2}}<br />
+                {{$match.Blue1}}<br />{{$match.Blue2}}
                 {{range $team := (index $.BlueOffFieldTeams $i) }}
                 <br />{{$team}}
                 {{end}}
@@ -97,7 +97,7 @@
         </div>
         <div class="col-lg-1 avatars">
           <img class="avatar" src="/api/teams/{{$match.Blue1}}/avatar" /><br />
-          <img class="avatar" src="/api/teams/{{$match.Blue2}}/avatar" /><br />
+          <img class="avatar" src="/api/teams/{{$match.Blue2}}/avatar" />
         </div>
       </div>
     {{end}}

--- a/templates/scoring_panel.html
+++ b/templates/scoring_panel.html
@@ -14,7 +14,7 @@
       <div>Exited Initiation Line?</div>
       <div>Endgame Status</div>
     </div>
-    {{range $i := seq 3}}
+    {{range $i := seq 2}}
       <div>
         <div id="team{{$i}}" class="team robot-field"></div>
         <div id="exitedInitiationLine{{$i}}" class="boolean robot-field" onclick="handleClick('{{$i}}');">


### PR DESCRIPTION
leaving 3v3 support in place, so it's easier to keep our fork in sync with cheesy-arena-lite. removing Red and Blue Team 3 from UI, and removing Red and Blue Team 3 from "match ready to start" checks.  (Could also auto-bypass Team 3's).

TODO: remove Team 3's from being included in schedule generator.