### PR TITLE
require authentication as 'ref' user to view ref pages

### DIFF
--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -34,6 +34,7 @@ type EventSettings struct {
 	SwitchPassword              string
 	PlcAddress                  string
 	AdminPassword               string
+	RefPassword                 string
 	WarmupDurationSec           int
 	AutoDurationSec             int
 	PauseDurationSec            int

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -141,6 +141,10 @@
             <div class="col-lg-7">
               <input type="password" class="form-control" name="adminPassword" value="{{.AdminPassword}}">
             </div>
+            <label class="col-lg-5 control-label">Password for 'ref' user</label>
+            <div class="col-lg-7">
+              <input type="password" class="form-control" name="refPassword" value="{{.RefPassword}}">
+            </div>
           </div>
         </fieldset>
         <fieldset>

--- a/web/headref_display.go
+++ b/web/headref_display.go
@@ -11,6 +11,10 @@ import (
 // through a websockets integration, the head ref will be able to see score updates submitted by other
 // refs in realtime.
 func (web *Web) headrefDisplayHandler(w http.ResponseWriter, r *http.Request) {
+	if !web.userIsAdmin(w, r) {
+		return
+	}
+
 	// if !web.enforceDisplayConfiguration(w, r, map[string]string{"background": "#0f0", "reversed": "false",
 	// 	"overlayLocation": "bottom"}) {
 	// 	return
@@ -41,6 +45,10 @@ func (web *Web) headrefDisplayHandler(w http.ResponseWriter, r *http.Request) {
 
 // The websocket endpoint for the ref display client to receive status updates.
 func (web *Web) headrefDisplayWebsocketHandler(w http.ResponseWriter, r *http.Request) {
+	if !web.userIsAdmin(w, r) {
+		return
+	}
+
 	ws, err := websocket.NewWebsocket(w, r)
 	if err != nil {
 		handleWebErr(w, err)

--- a/web/headref_display.go
+++ b/web/headref_display.go
@@ -11,7 +11,7 @@ import (
 // through a websockets integration, the head ref will be able to see score updates submitted by other
 // refs in realtime.
 func (web *Web) headrefDisplayHandler(w http.ResponseWriter, r *http.Request) {
-	if !web.userIsAdmin(w, r) {
+	if !web.userIsExpected(w, r, []string{adminUser, refUser}) {
 		return
 	}
 
@@ -45,7 +45,7 @@ func (web *Web) headrefDisplayHandler(w http.ResponseWriter, r *http.Request) {
 
 // The websocket endpoint for the ref display client to receive status updates.
 func (web *Web) headrefDisplayWebsocketHandler(w http.ResponseWriter, r *http.Request) {
-	if !web.userIsAdmin(w, r) {
+	if !web.userIsExpected(w, r, []string{adminUser, refUser}) {
 		return
 	}
 

--- a/web/ref_display.go
+++ b/web/ref_display.go
@@ -14,6 +14,10 @@ import (
 // field elements.  through a websockets integration, each ref will be able to see score updates
 // submitted by other refs in realtime.
 func (web *Web) refDisplayHandler(w http.ResponseWriter, r *http.Request) {
+	if !web.userIsAdmin(w, r) {
+		return
+	}
+
 	vars := mux.Vars(r)
 	alliance := vars["alliance"]
 	if alliance != "red" && alliance != "blue" {
@@ -48,6 +52,10 @@ func (web *Web) refDisplayHandler(w http.ResponseWriter, r *http.Request) {
 
 // The websocket endpoint for the ref display client to receive status updates.
 func (web *Web) refDisplayWebsocketHandler(w http.ResponseWriter, r *http.Request) {
+	if !web.userIsAdmin(w, r) {
+		return
+	}
+
 	ws, err := websocket.NewWebsocket(w, r)
 	if err != nil {
 		handleWebErr(w, err)

--- a/web/ref_display.go
+++ b/web/ref_display.go
@@ -14,7 +14,7 @@ import (
 // field elements.  through a websockets integration, each ref will be able to see score updates
 // submitted by other refs in realtime.
 func (web *Web) refDisplayHandler(w http.ResponseWriter, r *http.Request) {
-	if !web.userIsAdmin(w, r) {
+	if !web.userIsExpected(w, r, []string{adminUser, refUser}) {
 		return
 	}
 
@@ -52,7 +52,7 @@ func (web *Web) refDisplayHandler(w http.ResponseWriter, r *http.Request) {
 
 // The websocket endpoint for the ref display client to receive status updates.
 func (web *Web) refDisplayWebsocketHandler(w http.ResponseWriter, r *http.Request) {
-	if !web.userIsAdmin(w, r) {
+	if !web.userIsExpected(w, r, []string{adminUser, refUser}) {
 		return
 	}
 

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -7,7 +7,6 @@ package web
 
 import (
 	"fmt"
-	"github.com/Team254/cheesy-arena-lite/model"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Team254/cheesy-arena-lite/model"
 )
 
 // Shows the event settings editing page.
@@ -76,6 +77,7 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.SwitchPassword = r.PostFormValue("switchPassword")
 	eventSettings.PlcAddress = r.PostFormValue("plcAddress")
 	eventSettings.AdminPassword = r.PostFormValue("adminPassword")
+	eventSettings.RefPassword = r.PostFormValue("refPassword")
 	eventSettings.WarmupDurationSec, _ = strconv.Atoi(r.PostFormValue("warmupDurationSec"))
 	eventSettings.AutoDurationSec, _ = strconv.Atoi(r.PostFormValue("autoDurationSec"))
 	eventSettings.PauseDurationSec, _ = strconv.Atoi(r.PostFormValue("pauseDurationSec"))

--- a/web/web.go
+++ b/web/web.go
@@ -21,6 +21,7 @@ import (
 const (
 	sessionTokenCookie = "session_token"
 	adminUser          = "admin"
+	refUser            = "ref"
 )
 
 type Web struct {


### PR DESCRIPTION
- add ref password to settings
- require either ref or admin authentication in order to access ref pages